### PR TITLE
Add Gender Identity to list of hate speech

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -38,7 +38,7 @@ Redistribution and use in source and binary forms, with or without modification,
       * violence (except when required to protect public safety)
       * burning of forests
       * deforestation
-      * hate speech or discrimination based on age, gender, race, sexuality, religion, nationality
+      * hate speech or discrimination based on age, gender, gender identity, race, sexuality, religion, nationality
 
    b) lobbies against, or derives a majority of income from actions that discourage or frustrate:
       * peace


### PR DESCRIPTION
## Overview
Add Gender Identity to the list of hate speech/discrimination to embrace transgender+ people or people who do not conform with a gender norm.

<!-- Required. Describe why this is important/necessary? -->
Without this, it could lead to misunderstanding or exploitation.

## Proposed Resolution
<!-- Required. Describe, in detail, the desired resolution. -->
Simply add gender identity to the list of hate speech/discrimination.

## Notes
<!-- Optional. List additional notes/references as bullet points. Delete if unused. -->
[Understanding Gender](https://www.genderspectrum.org/quick-links/understanding-gender/)
[Gender Identity and Sexual Orientation](https://www.hrc.org/resources/sexual-orientation-and-gender-identity-terminology-and-definitions)