### PR TITLE
Fixed Apache 2.0 redistribution wording.

### DIFF
--- a/licenses/Apache-2.0-NoHarm.md
+++ b/licenses/Apache-2.0-NoHarm.md
@@ -104,17 +104,17 @@ You may reproduce and distribute copies of the Work or Derivative Works thereof 
 or without modifications, and in Source or Object form, provided that You meet the following
 conditions:
 
-1. You must give any other recipients of the Work or Derivative Works a copy of this License; and
+1. You must give any other recipients of the Work or Derivative Works a copy of this License.
 
 2. You must cause any modified files to carry prominent notices stating that You changed the
-   files; and
+   files.
 
 3. You must retain, in the Source form of any Derivative Works that You distribute, all copyright,
    patent, trademark, and attribution notices from the Source form of the Work, excluding those
-   notices that do not pertain to any part of the Derivative Works; and
+   notices that do not pertain to any part of the Derivative Works.
 
 4. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
-   or promote products derived from this software without specific prior written permission; and
+   or promote products derived from this software without specific prior written permission.
 
 5. This software must not be used by any organisation, website, product, or service that:
    1. lobbies for, promotes, or derives a majority of income from actions that support or contribute
@@ -133,16 +133,17 @@ conditions:
       * violence (except when required to protect public safety)
       * burning of forests
       * deforestation
-      * hate speech or discrimination based on age, gender, gender identity, race, sexuality, religion, nationality
+      * hate speech or discrimination based on age, gender, gender identity, race, sexuality,
+        religion, nationality
 
    2. lobbies against, or derives a majority of income from actions that discourage or frustrate:
       * peace
-      * access to the rights set out in the Universal Declaration of Human Rights and the Convention on the Rights of the Child
+      * access to the rights set out in the Universal Declaration of Human Rights and the Convention
+        on the Rights of the Child
       * peaceful assembly and association (including worker associations)
       * a safe environment or action to curtail the use of fossil fuels or prevent climate change
       * democratic processes
 
-   ; and
 5. If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative
    Works that You distribute must include a readable copy of the attribution notices contained
    within such NOTICE file, excluding those notices that do not pertain to any part of the


### PR DESCRIPTION
## Overview

Removed dangling use of `; and` after each ordered list item. In the
original Apache 2.0 license this reads better but with the inclusion of
the No Harm variant, it doesn't read as well.

Applied minor cleanup to word wrapping so paragraphs and list items are
capped at a column width of 100 characters as done when first
submitted.

## Proposed Resolution

Resolution is included in this commit. Only minor formatting applied.
