### PR TITLE
add caste to protected classes

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -116,7 +116,7 @@ conditions:
             * human trafficking
             * sex trafficking
             * slavery or indentured servitude
-            * discrimination based on age, gender, gender identity, race, sexuality, religion, nationality
+            * discrimination based on age, gender, gender identity, race, sexuality, religion, nationality, caste
             * hate speech
          2. **environmental destruction**:
             * the extraction or sale of fossil fuels


### PR DESCRIPTION
Explicitly stating caste as a protected class is beneficial to many people across various cultures.

- [California accuses Cisco of job discrimination based on Indian employee's caste](https://www.reuters.com/article/us-cisco-lawsuit/california-accuses-cisco-of-job-discrimination-based-on-indian-employees-caste-idUSKBN2423YE)
- [Seattle becomes first US city to ban caste discrimination](https://www.bbc.com/news/world-us-canada-64727735)
